### PR TITLE
Dismissal Timer did not reset on dismiss.

### DIFF
--- a/GTNotification/GTNotificationManager.swift
+++ b/GTNotification/GTNotificationManager.swift
@@ -666,6 +666,10 @@ public class GTNotificationManager: NSObject, GTNotificationViewDelegate
     */
     public func dismissCurrentNotification() {
         if let notificationView = self.currentNotificationView {
+            
+            self.dismissalTimer?.invalidate()
+            self.dismissalTimer = nil
+            
             // Animate the notification
             notificationView.animateNotification(willShow: false, completion: {
                 (finished: Bool) -> Void in


### PR DESCRIPTION
Attempted to dismiss and reshow a different GTNotification.

But the previous timer trigger and made the 2nd Notification to dismiss earlier than expected
